### PR TITLE
Feature/#17728 Integration with SAML

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -15,9 +15,9 @@ action :add do
     memcached_servers = new_resource.memcached_servers
     http_workers = [[10 * node['cpu']['total'].to_i, (memory_kb / (3 * 1024 * 1024)).floor ].min, 1].max.to_i
     auth_mode = new_resource.sso_enabled
-    
+
     if node['redborder']['sso_enabled'] == '1'
-      auth_mode = "saml"
+      auth_mode = 'saml'
     end
 
     # INSTALLATION

--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -14,6 +14,11 @@ action :add do
     elasticache_hosts = new_resource.elasticache_hosts
     memcached_servers = new_resource.memcached_servers
     http_workers = [[10 * node['cpu']['total'].to_i, (memory_kb / (3 * 1024 * 1024)).floor ].min, 1].max.to_i
+    auth_mode = new_resource.sso_enabled
+    
+    if node['redborder']['sso_enabled'] == '1'
+      auth_mode = "saml"
+    end
 
     # INSTALLATION
     # begin
@@ -286,7 +291,8 @@ action :add do
       retries 2
       cookbook 'webui'
       variables(cdomain: cdomain,
-                webui_secret_token: webui_secret_token)
+                webui_secret_token: webui_secret_token,
+                auth_mode: auth_mode)
       notifies :restart, 'service[webui]', :delayed
       notifies :restart, 'service[rb-workers]', :delayed
     end

--- a/resources/resources/config.rb
+++ b/resources/resources/config.rb
@@ -16,3 +16,4 @@ attribute :memory_kb, kind_of: Integer
 attribute :elasticache_hosts, kind_of: Object
 attribute :zk_hosts, kind_of: String
 attribute :s3_local_storage, kind_of: String, default: 'minio'
+attribute :sso_enabled, kind_of: String, default: 'database'

--- a/resources/templates/default/redborder_config.yml.erb
+++ b/resources/templates/default/redborder_config.yml.erb
@@ -1,7 +1,7 @@
 <% [ "production", "development" ].each do |x| %>
 <%= x %>:
   mailer_sender: 'alarm@<%= @cdomain %>'
-  authentication_mode: database
+  authentication_mode: <%= @auth_mode %>
   secret: <%= @webui_secret_token %>
   rsa_filename: rsa
   url: '<%= @cdomain %>'


### PR DESCRIPTION
## Related issue in RedMine
[Feature #17728: [manager] Integration with SAML (SSO Login System)](https://redmine.redborder.lan/issues/17728)

## Description / Motivation

Add a new variable in templates/default/redborder_config.yml.erb.

## Detail

To enable/disable SSO, the value of `authentication_mode` must be `saml` or `database`. The default value is database, but if there is a value in node with the settings value that show that the SSO login system is enabled, changes the value to "saml"