### PR TITLE
Bugfix/#22675 change aerospike port

### DIFF
--- a/resources/libraries/helper.rb
+++ b/resources/libraries/helper.rb
@@ -122,7 +122,7 @@ module Webui
                node_obj['fqdn'] ||
                (node_obj.respond_to?(:name) ? node_obj.name : node_obj['name'])
 
-        port = (node_obj.dig('aerospike', 'port') || 5000).to_i
+        port = (node_obj.dig('aerospike', 'port') || 3000).to_i
 
         host && port ? "#{host}:#{port}" : nil
       end


### PR DESCRIPTION
The Legacy and the aerospike port by default is 3000. No sense to change to 5000